### PR TITLE
Added swipe events to slider

### DIFF
--- a/src/js/jquery.galereya.js
+++ b/src/js/jquery.galereya.js
@@ -583,6 +583,9 @@
                     startSlideShow(); //resume slide show when an image is loaded
                 }
             });
+            // Requires jquery-mobile
+            $slide.on('swiperight', Handlers.sliderPrevClick);
+            $slide.on('swipeleft', Handlers.sliderNextClick);
 
             return $slide;
         };


### PR DESCRIPTION
This very basic change adds the possibility to swipe the image slider left/right when jquery mobile is added to the page.
For that one only needs to add the following two lines to the html:
  <link rel="stylesheet" href="//code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.css">
  <script src="//code.jquery.com/mobile/1.4.5/jquery.mobile-1.4.5.min.js"></script>

Without that the change is harmless.